### PR TITLE
Make forms for add and edit scrollable

### DIFF
--- a/res/layout/activity_bookmark_add.xml
+++ b/res/layout/activity_bookmark_add.xml
@@ -10,65 +10,80 @@
 			android:layout_centerVertical="true"
 			android:layout_centerInParent="true"
 			android:visibility="gone" />
-	
-	<LinearLayout
-	    android:id="@+id/form"
-	    android:layout_width="match_parent"
-	    android:layout_height="match_parent"
-	    android:padding="12dp"
-	    android:orientation="vertical">
-		
-		<TextView
-			android:text="@string/url_label"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<EditText
-			android:id="@+id/url"
-			android:inputType="textUri"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<TextView
-			android:text="@string/title_label"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<EditText
-			android:id="@+id/title"
-			android:inputType="text"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content" />
-		<TextView
-			android:text="@string/description_label"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<EditText
-			android:id="@+id/description"
-			android:inputType="text|textMultiLine"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content" />
-		<TextView
-			android:text="@string/tags_label"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<EditText
-			android:id="@+id/tags"
-			android:inputType="text|textNoSuggestions"
-			android:singleLine="true"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<TextView
-			android:text="@string/status_label"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-		<Spinner 
-			android:id="@+id/status"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:prompt="@string/status_prompt"/>
-		<Button
-			android:id="@+id/save_button"
-			android:text="@string/save"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"/>
-	    
-	</LinearLayout>
+
+    <ScrollView
+        android:layout_height="match_parent"
+        android:layout_width="match_parent">
+
+        <LinearLayout
+            android:id="@+id/form"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="12dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:text="@string/url_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/url"
+                android:inputType="textUri"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/title_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/title"
+                android:inputType="text"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/description_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/description"
+                android:inputType="text|textMultiLine"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/tags_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/tags"
+                android:inputType="text|textNoSuggestions"
+                android:singleLine="true"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/status_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <Spinner
+                android:id="@+id/status"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:prompt="@string/status_prompt" />
+
+            <Button
+                android:id="@+id/save_button"
+                android:text="@string/save"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+    </ScrollView>
 </RelativeLayout>

--- a/res/layout/activity_bookmark_edit.xml
+++ b/res/layout/activity_bookmark_edit.xml
@@ -2,60 +2,81 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="12dp"
     android:orientation="vertical">
-	
-	<TextView
-		android:text="@string/url_label"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<TextView
-		android:id="@+id/url"
-		android:textIsSelectable="true"
-		android:singleLine="true"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<TextView
-		android:text="@string/title_label"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<EditText
-		android:id="@+id/title"
-		android:inputType="text"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content" />
-	<TextView
-		android:text="@string/description_label"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<EditText
-		android:id="@+id/description"
-		android:inputType="text|textMultiLine"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content" />
-	<TextView
-		android:text="@string/tags_label"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<EditText
-		android:id="@+id/tags"
-		android:inputType="text|textNoSuggestions"
-		android:singleLine="true"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<TextView
-		android:text="@string/status_label"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-	<Spinner 
-		android:id="@+id/status"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:prompt="@string/status_prompt"/>
-	<Button
-		android:id="@+id/save_button"
-		android:text="@string/save"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"/>
-    
+
+    <ScrollView
+        android:layout_height="match_parent"
+        android:layout_width="match_parent">
+
+        <LinearLayout
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            android:padding="12dp"
+            android:orientation="vertical">
+
+
+            <TextView
+                android:text="@string/url_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/url"
+                android:textIsSelectable="true"
+                android:singleLine="true"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/title_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/title"
+                android:inputType="text"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/description_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/description"
+                android:inputType="text|textMultiLine"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/tags_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/tags"
+                android:inputType="text|textNoSuggestions"
+                android:singleLine="true"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:text="@string/status_label"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <Spinner
+                android:id="@+id/status"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:prompt="@string/status_prompt" />
+
+            <Button
+                android:id="@+id/save_button"
+                android:text="@string/save"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>


### PR DESCRIPTION
Hi,
Just a little cosmetic fix.
In the current version it is not possible to scroll in the add and edit activity. If the keyboard is shown, some of the forms content may be hidden (it is on my screen) and one has to close the keyboard to get to those hidden form elements.
I solved it by wrapping the form inside a ScrollView. I've been using it in the past few days without problems.
