### PR TITLE
Fix settings screen on tablets

### DIFF
--- a/src/gr/ndre/scuttloid/SettingsActivity.java
+++ b/src/gr/ndre/scuttloid/SettingsActivity.java
@@ -18,11 +18,11 @@
 
 package gr.ndre.scuttloid;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
-import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.text.InputType;
@@ -31,9 +31,9 @@ import android.text.InputType;
 /**
  * Settings screen
  */
-public class SettingsActivity extends PreferenceActivity {
-	
-	/**
+public class SettingsActivity extends Activity {
+
+    /**
 	 * A preference value change listener that updates the preference's summary
 	 * to reflect its new value.
 	 */


### PR DESCRIPTION
Hi again,
another little cosmetic fix. On tablets the settings screen (and therefore the first screen a user will see of the app) looks like this:
![screenshot_2014-01-03-19-26-49](https://f.cloud.github.com/assets/1621900/1904009/8fbf7870-7c89-11e3-9873-5dd31b145e4b.png)
Borders are visible left and right, while the content does not seem to fit into this box, especially the checkbox.

It seems to be a problem with using a single preferenceFragment inside a preferenceActivity. The official Settings guide states: ["You can add a PreferenceFragment to any activity—you don't need to use PreferenceActivity"](http://developer.android.com/guide/topics/ui/settings.html#Fragment)
Apparently it's even necessary not use a PreferenceActivity here.

I assume, an other solution would be not to use the PreferenceFragment, although the developer guide recommends to use it.
