### PR TITLE
Fix: Crash when adding with share function

### DIFF
--- a/src/gr/ndre/scuttloid/BookmarkAddActivity.java
+++ b/src/gr/ndre/scuttloid/BookmarkAddActivity.java
@@ -140,9 +140,12 @@ public class BookmarkAddActivity extends Activity
 
 	@Override
 	public void onBookmarkCreated() {
-		BookmarkContent.getShared().addItemToTop(this.item);
-		Toast.makeText(this, getString(R.string.bookmark_created), Toast.LENGTH_SHORT).show();
-		finish();
+        BookmarkContent shared = BookmarkContent.getShared();
+        if (shared != null) {
+            shared.addItemToTop(this.item);
+        }
+        Toast.makeText(this, getString(R.string.bookmark_created), Toast.LENGTH_SHORT).show();
+        finish();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes [issue#3](https://github.com/ilesinge/scuttloid/issues/3)

The trick was to check if the bookmarkContent was initialized.
I realized, that the app only crashes, if it is fully closed (removed from the multitasking screen). In case that you want to reproduce the problem.

PS: I'm sorry, I don't know how to attach this to issue#3
